### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# winrmlib (beta) [![Build Status](https://travis-ci.org/ianclegg/winrmlib.svg?branch=master)](https://travis-ci.org/ianclegg/winrmlib) [![Downloads](https://pypip.in/download/winrmlib/badge.svg)](https://pypi.python.org/pypi/winrmlib/) [![Latest Version](https://pypip.in/version/winrmlib/badge.svg)](https://pypi.python.org/pypi/winrmlib/)
+# winrmlib (beta) [![Build Status](https://travis-ci.org/ianclegg/winrmlib.svg?branch=master)](https://travis-ci.org/ianclegg/winrmlib) [![Downloads](https://img.shields.io/pypi/dm/winrmlib.svg)](https://pypi.python.org/pypi/winrmlib/) [![Latest Version](https://img.shields.io/pypi/v/winrmlib.svg)](https://pypi.python.org/pypi/winrmlib/)
 
 ## Vision:
 A robust, fast and efficient 'first-class' Python Library for Windows Remote Management


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20winrmlib))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `winrmlib`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.